### PR TITLE
Fix PHP 5.4 bug

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -799,7 +799,8 @@ class OpenIDConnectClient
         $ccm = $this->getCodeChallengeMethod();
         $cv = $this->getCodeVerifier();
         if (!empty($ccm) && !empty($cv)) {
-            if (empty($this->getClientSecret())) {
+            $cs = $this->getClientSecret();
+            if (empty($cs)) {
                 $authorizationHeader = null;
                 unset($token_params['client_secret']);
             }


### PR DESCRIPTION
Fix the following error: 

```
Fatal error: Can't use method return value in write context in (...)/src/OpenIDConnectClient.php on line 802
```

**List of common tasks a pull request require complete**
- [X] Changelog entry is added or the pull request don't alter library's functionality
